### PR TITLE
Added support for tasks deleted in ppm due to unmet request URL criteria.

### DIFF
--- a/src/com/ppm/integration/agilesdk/connector/versionone/VersionOneService.java
+++ b/src/com/ppm/integration/agilesdk/connector/versionone/VersionOneService.java
@@ -443,19 +443,17 @@ public class VersionOneService {
         if (StringUtils.isNullOrEmptyOrBlank(emailField)) { emailField =  DEFAULT_EMAIL_FIELD; }
         emailField = emailField.replace("%WBS_ID%", wbsID);
 
-        String getString =  values.get(KEY_AGILITY_REST_URL);
-        if (StringUtils.isNullOrEmptyOrBlank(getString)) {getString =  DEFAULT_AGILITY_REST_URL;}
-        getString = getString.replace("%WBS_ID%", wbsID);
-
-        getString = getString.split("&where")[0];
+        String agilityUrl = values.get(KEY_AGILITY_REST_URL);
+        if (StringUtils.isNullOrEmptyOrBlank(agilityUrl)) {
+            agilityUrl = DEFAULT_AGILITY_REST_URL;
+        }
+        agilityUrl = agilityUrl.replace("%WBS_ID%", wbsID);
+        StringBuilder reqUrl = new StringBuilder(agilityUrl.split("&where")[0]);
         String joinedIds = String.join(",", taskIds.stream().map(id -> "%27" + id + "%27") .toArray(String[]::new));
-        getString = getString + (String.format("&where=(Number=%s)",joinedIds));
+        reqUrl.append("&where=(Number=").append(joinedIds).append(")");
+        String finalUrl = baseUri + encodeUrl(reqUrl.toString());
 
-        getString = encodeUrl(getString);
-
-        getString = baseUri + getString;
-
-        ClientResponse response = wrapper.sendGet(getString);
+        ClientResponse response = wrapper.sendGet(finalUrl);
         String jsonStr = response.getEntity(String.class);
 
         if (logger.isDebugEnabled()) {

--- a/src/com/ppm/integration/agilesdk/connector/versionone/VersionOneService.java
+++ b/src/com/ppm/integration/agilesdk/connector/versionone/VersionOneService.java
@@ -436,10 +436,43 @@ public class VersionOneService {
 
         return epics;
     }*/
+    public List<VersionOneEpic> importEpicFeaturesEntitiesByIds(List<String> taskIds,
+                                             VersionOneWorkPlanIntegration.TaskCreationContext taskContext, String wbsID, ValueSet values) {
 
+        String emailField = values.get(KEY_AGILITY_EMAIL_FIELD);
+        if (StringUtils.isNullOrEmptyOrBlank(emailField)) { emailField =  DEFAULT_EMAIL_FIELD; }
+        emailField = emailField.replace("%WBS_ID%", wbsID);
+
+        String getString =  values.get(KEY_AGILITY_REST_URL);
+        if (StringUtils.isNullOrEmptyOrBlank(getString)) {getString =  DEFAULT_AGILITY_REST_URL;}
+        getString = getString.replace("%WBS_ID%", wbsID);
+
+        getString = getString.split("&where")[0];
+        String joinedIds = String.join(",", taskIds.stream().map(id -> "%27" + id + "%27") .toArray(String[]::new));
+        getString = getString + (String.format("&where=(Number=%s)",joinedIds));
+
+        getString = encodeUrl(getString);
+
+        getString = baseUri + getString;
+
+        ClientResponse response = wrapper.sendGet(getString);
+        String jsonStr = response.getEntity(String.class);
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("<=== Received JSon: "+jsonStr);
+        }
+
+        try {
+
+            return prepareEpics(taskContext, values, jsonStr, emailField);
+
+        } catch (JSONException e) {
+            logger.error("", e);
+        }
+
+        return new ArrayList<>();
+    }
     public List<VersionOneEpic> importEpicFeaturesEntities(VersionOneWorkPlanIntegration.TaskCreationContext taskContext, String wbsID, ValueSet values) {
-
-        List<VersionOneEpic> epics = new ArrayList<>();
         String emailField = values.get(KEY_AGILITY_EMAIL_FIELD);
         if (StringUtils.isNullOrEmptyOrBlank(emailField)) { emailField =  DEFAULT_EMAIL_FIELD; }
         emailField = emailField.replace("%WBS_ID%", wbsID);
@@ -462,56 +495,58 @@ public class VersionOneService {
 
         try {
 
-            JSONObject jsonObj = new JSONObject(jsonStr);
-
-            JSONArray jsonAssets = jsonObj.getJSONArray("Assets");
-            for (int i = 0; i < jsonAssets.length(); i++) {
-                JSONObject asset = jsonAssets.getJSONObject(i);
-                JSONObject attributes = asset.getJSONObject("Attributes");
-                String name = attributes.getJSONObject("Name").getString("value");
-                String id = asset.getString("id");
-                String statusName = attributes.getJSONObject("Status.Name").getString("value");
-                String createDate = attributes.getJSONObject("CreateDate").getString("value");
-                String number = attributes.getJSONObject("Number").getString("value");
-
-
-
-
-                String plannedStart = attributes.has("PlannedStart") ? attributes.getJSONObject("PlannedStart").getString("value") : null;
-                String plannedEnd = attributes.has("PlannedEnd") ? attributes.getJSONObject("PlannedEnd").getString("value") : null;
-
-                VersionOneEpic epic = new VersionOneEpic(id, number, name, statusName, createDate, plannedStart, plannedEnd, taskContext);
-                epic.setOwnersNames(attributes.getJSONObject(emailField));
-
-                // Setting first Criteria & Second Criteria for custom logic of sub-tasks creation
-                String firstCriteriaField = values.get(KEY_AGILITY_FIRST_CRITERIA_FIELD);
-                if (!StringUtils.isNullOrEmptyOrBlank(firstCriteriaField)) {
-                    JSONObject obj = attributes.getJSONObject(firstCriteriaField);
-                    if (obj != null && obj.has("value")) {
-                        String value = obj.getString("value");
-                        if (value != null) {
-                            epic.setFirstCriteria(value);
-                        }
-                    }
-                }
-                String secondCriteriaField = values.get(KEY_AGILITY_SECOND_CRITERIA_FIELD);
-                if (!StringUtils.isNullOrEmptyOrBlank(secondCriteriaField)) {
-                    JSONObject obj = attributes.getJSONObject(secondCriteriaField);
-                    if (obj != null && obj.has("value")) {
-                        String value = obj.getString("value");
-                        if (value != null) {
-                            epic.setSecondCriteria(value);
-                        }
-                    }
-                }
-
-                epics.add(epic);
-            }
+            return prepareEpics(taskContext, values, jsonStr, emailField);
 
         } catch (JSONException e) {
             logger.error("", e);
         }
 
+        return new ArrayList<>();
+    }
+
+    private static List<VersionOneEpic> prepareEpics(VersionOneWorkPlanIntegration.TaskCreationContext taskContext, ValueSet values, String jsonStr, String emailField) {
+        JSONObject jsonObj = new JSONObject(jsonStr);
+        List<VersionOneEpic> epics = new ArrayList<>();
+        JSONArray jsonAssets = jsonObj.getJSONArray("Assets");
+        for (int i = 0; i < jsonAssets.length(); i++) {
+            JSONObject asset = jsonAssets.getJSONObject(i);
+            JSONObject attributes = asset.getJSONObject("Attributes");
+            String name = attributes.getJSONObject("Name").getString("value");
+            String id = asset.getString("id");
+            String statusName = attributes.getJSONObject("Status.Name").getString("value");
+            String createDate = attributes.getJSONObject("CreateDate").getString("value");
+            String number = attributes.getJSONObject("Number").getString("value");
+
+            String plannedStart = attributes.has("PlannedStart") ? attributes.getJSONObject("PlannedStart").getString("value") : null;
+            String plannedEnd = attributes.has("PlannedEnd") ? attributes.getJSONObject("PlannedEnd").getString("value") : null;
+
+            VersionOneEpic epic = new VersionOneEpic(id, number, name, statusName, createDate, plannedStart, plannedEnd, taskContext);
+            epic.setOwnersNames(attributes.getJSONObject(emailField));
+
+            // Setting first Criteria & Second Criteria for custom logic of sub-tasks creation
+            String firstCriteriaField = values.get(KEY_AGILITY_FIRST_CRITERIA_FIELD);
+            if (!StringUtils.isNullOrEmptyOrBlank(firstCriteriaField)) {
+                JSONObject obj = attributes.getJSONObject(firstCriteriaField);
+                if (obj != null && obj.has("value")) {
+                    String value = obj.getString("value");
+                    if (value != null) {
+                        epic.setFirstCriteria(value);
+                    }
+                }
+            }
+            String secondCriteriaField = values.get(KEY_AGILITY_SECOND_CRITERIA_FIELD);
+            if (!StringUtils.isNullOrEmptyOrBlank(secondCriteriaField)) {
+                JSONObject obj = attributes.getJSONObject(secondCriteriaField);
+                if (obj != null && obj.has("value")) {
+                    String value = obj.getString("value");
+                    if (value != null) {
+                        epic.setSecondCriteria(value);
+                    }
+                }
+            }
+
+            epics.add(epic);
+        }
         return epics;
     }
 }

--- a/src/com/ppm/integration/agilesdk/connector/versionone/VersionOneWorkPlanIntegration.java
+++ b/src/com/ppm/integration/agilesdk/connector/versionone/VersionOneWorkPlanIntegration.java
@@ -109,6 +109,7 @@ public class VersionOneWorkPlanIntegration extends WorkPlanIntegration {
     @Override
     public ExternalWorkPlan getExternalWorkPlan(WorkPlanIntegrationContext context, ValueSet values) {
 
+        Long taskId = context.currentTask().getId();
         String wbsID = getWBSId(context, values);
 
         configureService(values);
@@ -123,12 +124,68 @@ public class VersionOneWorkPlanIntegration extends WorkPlanIntegration {
         final List<VersionOneEpic> epics = service.importEpicFeaturesEntities(taskContext, wbsID, values);
         externalTasks.addAll(epics);
 
+        List<VersionOneEpic> newEpics = importEpicFeaturesFromPpmTasks(epics,taskId,taskContext,wbsID,values );
+        if(newEpics !=null && !newEpics.isEmpty()){
+            externalTasks.addAll(newEpics);
+        }
+
         return new ExternalWorkPlan() {
             @Override
             public List<ExternalTask> getRootTasks() {
                 return externalTasks;
             }
         };
+    }
+
+    private List<VersionOneEpic> importEpicFeaturesFromPpmTasks(List<VersionOneEpic> epics,final Long taskId,
+                                                             VersionOneWorkPlanIntegration.TaskCreationContext taskContext, String wbsID, ValueSet values){
+        if(epics==null || epics.isEmpty()){
+            return null;
+        }
+
+        List<String> agilityTasks = new ArrayList<>();
+        for(VersionOneEpic eachEpic : epics){
+            // here the name is associated with the unique task numbers
+            agilityTasks.add(eachEpic.getName());
+        }
+        HibernateTemplate wp = new HibernateTemplate() {
+            @Override
+            public void run() throws Exception {
+                NativeQuery query = getSession().createNativeQuery("SELECT NAME FROM wp_task_info WHERE task_info_id IN (SELECT TASK_ACTUALS_ID FROM wp_tasks WHERE WP_TASKS.PARENT_TASK_ID = :taskId)");
+                query.setParameter("taskId", taskId);
+                query.addScalar("NAME", StandardBasicTypes.STRING);
+                setResult(query.list());
+            }
+        };
+        wp.doRun();
+        List<String> ppmChildTasks = (List<String>)wp.getResult();
+        if(ppmChildTasks == null || ppmChildTasks.isEmpty()){
+            return null;
+        }
+        List<String> missedTasks = new ArrayList<>();
+        for(String eachChildTask : ppmChildTasks){
+            if(!agilityTasks.contains(eachChildTask)
+                && eachChildTask.contains(":")){
+                missedTasks.add(eachChildTask.split(":")[0]);
+            }
+        }
+        if(missedTasks==null || missedTasks.isEmpty()){
+            return null;
+        }
+        List<VersionOneEpic> allTasks = new ArrayList<>();
+        int batchSize = 100;
+        for (int i = 0; i < missedTasks.size(); i += batchSize) {
+            List<String> batch = missedTasks.subList(i, Math.min(i + batchSize, missedTasks.size()));
+            List<VersionOneEpic> batchResult = service.importEpicFeaturesEntitiesByIds(batch, taskContext, wbsID, values);
+            if(batchResult!=null && !batchResult.isEmpty()){
+                for(VersionOneEpic eachEpic : batchResult){
+                    // to mark requests completed which are not in the part of first sync
+                    eachEpic.setStatusName("Done");
+                }
+                allTasks.addAll(batchResult);
+            }
+        }
+        return allTasks;
     }
 
     private ExternalTask getWrappingTask(String wrappingTaskName, List<? extends ExternalTask> tasks) {

--- a/src/com/ppm/integration/agilesdk/connector/versionone/VersionOneWorkPlanIntegration.java
+++ b/src/com/ppm/integration/agilesdk/connector/versionone/VersionOneWorkPlanIntegration.java
@@ -139,10 +139,6 @@ public class VersionOneWorkPlanIntegration extends WorkPlanIntegration {
 
     private List<VersionOneEpic> importEpicFeaturesFromPpmTasks(List<VersionOneEpic> epics,final Long taskId,
                                                              VersionOneWorkPlanIntegration.TaskCreationContext taskContext, String wbsID, ValueSet values){
-        if(epics==null || epics.isEmpty()){
-            return null;
-        }
-
         List<String> agilityTasks = new ArrayList<>();
         for(VersionOneEpic eachEpic : epics){
             // here the name is associated with the unique task numbers
@@ -151,7 +147,7 @@ public class VersionOneWorkPlanIntegration extends WorkPlanIntegration {
         HibernateTemplate wp = new HibernateTemplate() {
             @Override
             public void run() throws Exception {
-                NativeQuery query = getSession().createNativeQuery("SELECT NAME FROM wp_task_info WHERE task_info_id IN (SELECT TASK_ACTUALS_ID FROM wp_tasks WHERE WP_TASKS.PARENT_TASK_ID = :taskId)");
+                NativeQuery query = getSession().createNativeQuery("SELECT NAME FROM wp_task_info WHERE wp_task_info.OWNER_TASK_ID IN (SELECT TASK_ID FROM wp_tasks WHERE WP_TASKS.PARENT_TASK_ID = :taskId)");
                 query.setParameter("taskId", taskId);
                 query.addScalar("NAME", StandardBasicTypes.STRING);
                 setResult(query.list());

--- a/src/com/ppm/integration/agilesdk/connector/versionone/VersionOneWorkPlanIntegration.java
+++ b/src/com/ppm/integration/agilesdk/connector/versionone/VersionOneWorkPlanIntegration.java
@@ -293,11 +293,26 @@ public class VersionOneWorkPlanIntegration extends WorkPlanIntegration {
                 userProvider = Providers.getUserProvider(VersionOneIntegrationConnector.class);
             }
             User u = userProvider.getByUsername(owner);
-            if (u == null) {
-                u = userProvider.getByEmail(owner);
+            if(u != null){
+                return u.getUserId();
             }
-            return u == null ? null : u.getUserId();
+            return getByEmail(owner);
+
         }
     }
 
+        private Long getByEmail(String email) {
+            HibernateTemplate wp = new HibernateTemplate() {
+
+                @Override
+                public void run() throws Exception {
+                    NativeQuery query = getSession().createNativeQuery("select USER_ID as userId from KNTA_USERS where LOWER(email_address) = :email ORDER BY END_DATE desc  FETCH FIRST 1 ROWS ONLY");
+                    query.setParameter("email", email);
+                    query.addScalar("userId", StandardBasicTypes.LONG);
+                    setResult(query.uniqueResult());
+                }
+            };
+            wp.doRun();
+            return (Long) wp.getResult();
+        }
 }


### PR DESCRIPTION
**Issue**
Whenever a task status is moved to In Progress, it syncs correctly in PPM. However, once the status changes to Done, the task gets deleted in PPM.

**Root Cause**
The request sent to VersionOne (Agility) applies a status filter that excludes tasks in Done state. As a result, PPM cannot find the task in the response and deletes it from the project.

**Fix**
Added logic to send a second request that fetches tasks already present in PPM but missing from the Agility response. This ensures tasks in Done status remain in PPM and are not deleted.


**Issue 2**
Task sync fails because user is not picked.

**Root Cause**
User sync is based on email; duplicate users exist with same email (one active, other inactive).

**Fix**
Prioritize active user for sync; fallback to inactive only if active not found.
