### PR TITLE
US#1880913 Sub Task Creation Logic Update And Migration Changes

### DIFF
--- a/src/com/ppm/integration/agilesdk/connector/versionone/VersionOneConstants.java
+++ b/src/com/ppm/integration/agilesdk/connector/versionone/VersionOneConstants.java
@@ -73,6 +73,8 @@ public interface VersionOneConstants {
 
     String KEY_PPM_REQUEST_FIELD_TYPE = "PPM_REQUEST_FIELD_TYPE";
 
+    String KEY_PPM_RESTRICT_TASK_DELETE = "PPM_RESTRICT_TASK_DELETE";
+
     String PPM_REQUEST_FIELD_TYPE_REQUEST_HEADER = "reqFieldRequestHeader";
 
     String PPM_REQUEST_FIELD_TYPE_REQUEST_DETAILS = "reqFieldRequestDetails";

--- a/src/com/ppm/integration/agilesdk/connector/versionone/VersionOneIntegrationConnector.java
+++ b/src/com/ppm/integration/agilesdk/connector/versionone/VersionOneIntegrationConnector.java
@@ -82,6 +82,7 @@ public class VersionOneIntegrationConnector extends IntegrationConnector {
                 getColumnSelect(),
                 getBatchSelect(),
                 new LineBreaker(),
+                new CheckBox(VersionOneConstants.KEY_PPM_RESTRICT_TASK_DELETE, "PPM_RESTRICT_TASK_DELETE", false),
         });
     }
 

--- a/src/com/ppm/integration/agilesdk/connector/versionone/VersionOneIntegrationConnector.properties
+++ b/src/com/ppm/integration/agilesdk/connector/versionone/VersionOneIntegrationConnector.properties
@@ -62,6 +62,7 @@ AGILITY_EMAIL_FIELD=Name of the field from which to retrieve email addresses:
 AGILITY_FIRST_CRITERIA_FIELD=First criteria field used to create Tasks:
 AGILITY_SECOND_CRITERIA_FIELD=Second criteria field used to create Tasks:
 PPM_REQUEST_FIELD_TYPE=Type of field in PPM Project:
+PPM_RESTRICT_TASK_DELETE=Prevent deletion and cancellation of tasks (Agility)
 REQUEST_FIELD_TYPE_REQUEST_HEADER=Request Header
 REQUEST_FIELD_TYPE_REQUEST_DETAILS=Request Details
 PPM_REQUEST_FIELD_PARAMETER_TYPE= Which DB column to read from?

--- a/src/com/ppm/integration/agilesdk/connector/versionone/delta/DeltaSubTaskCreationLogic.java
+++ b/src/com/ppm/integration/agilesdk/connector/versionone/delta/DeltaSubTaskCreationLogic.java
@@ -19,16 +19,23 @@ public class DeltaSubTaskCreationLogic {
         switch(fundingType) {
             case "SaaS":
                 childrenNames.add("SaaS");
+                break;
+            case "Restoration":
                 childrenNames.add("OP");
                 break;
             default: // CapEx or Opex or empty
                 switch (fundingLevel) {
+                    case "Pillars/Pillar Enablers":
+                    case "Mandates":
+                    case "CBF - New Builds/Enhancements":
                     case "BAU (OpEx)":
-                        childrenNames.add("OP"); // Opex Only
+                        childrenNames.add("CAP");
+                        break;
+                    case "CBF - Fix Broken Experiences":
+                        childrenNames.add("OP");
                         break;
                     default:
                         childrenNames.add("CAP");
-                        childrenNames.add("OP");
                         break;
                 }
                 break;

--- a/src/com/ppm/integration/agilesdk/connector/versionone/delta/DeltaSubTaskCreationLogic.java
+++ b/src/com/ppm/integration/agilesdk/connector/versionone/delta/DeltaSubTaskCreationLogic.java
@@ -20,22 +20,22 @@ public class DeltaSubTaskCreationLogic {
             case "SaaS":
                 childrenNames.add("SaaS");
                 break;
-            case "Restoration":
+            case "Exploration":
                 childrenNames.add("OP");
                 break;
             default: // CapEx or Opex or empty
                 switch (fundingLevel) {
-                    case "Pillars/Pillar Enablers":
+                    case "Pillars / Enablers":
                     case "Mandates":
-                    case "CBF - New Builds/Enhancements":
-                    case "BAU (OpEx)":
+                    case "CBF - Critical Business Foundations":
                         childrenNames.add("CAP");
                         break;
+                    case "BAU (OpEx)":
                     case "CBF - Fix Broken Experiences":
                         childrenNames.add("OP");
                         break;
                     default:
-                        childrenNames.add("CAP");
+                        childrenNames.add("OP");
                         break;
                 }
                 break;


### PR DESCRIPTION
The changes implemented for subtask creation during Agility-to-PPM sync required updates to the existing Task Mapping Logic. As part of this enhancement, a new flag has been introduced to determine whether certain tasks should be preserved instead of being deleted.

During migration, the behavior differs from the old logic—for example, earlier the system created two subtasks, whereas the updated logic creates only one. After applying the new logic, the additional (legacy) task is marked as Completed. If the preservation flag is enabled, this task will be retained; otherwise, it will be deleted as part of the cleanup process